### PR TITLE
Update TWRPConfig.mk

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -103,6 +103,7 @@ TARGET_USE_CUSTOM_LUN_FILE_PATH := /config/usb_gadget/g1/functions/mass_storage.
 
 # Qualcomm
 QCOM_BOARD_PLATFORMS := $(PRODUCT_PLATFORM)
+RECOVERY_SDCARD_ON_DATA := true
 
 # Anti-Roll Back
 PLATFORM_SECURITY_PATCH := 2099-12-31

--- a/TWRPConfig.mk
+++ b/TWRPConfig.mk
@@ -1,6 +1,6 @@
 # Include in BoardConfig.mk
 TW_THEME := portrait_hdpi
-RECOVERY_SDCARD_ON_DATA := true
+TW_INCLUDE_REPACKTOOLS := true
 TW_INCLUDE_RESETPROP := true
 TW_EXCLUDE_DEFAULT_USB_INIT := true
 TW_EXTRA_LANGUAGES := true


### PR DESCRIPTION
- Removed RECOVERY_SDCARD_ON_DATA := true; will be places in main BoardConfig makefiles.
- Define TW_INCLUDE_REPACKTOOLS as true; attempt to prevent from stock replacing twrp.

Signed-off-by: Carlo Dee <carlodee.official@proton.me>